### PR TITLE
Ruff linter/formatter updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
-          pip install black
           pip install ruff
       
-      - name: Run Ruff (Linting)
+      - name: Run Ruff Linting Check
         run: ruff check .
-      
-      - name: Check formatting with Black
-        run: black --check .
 
+      - name: Run Ruff Formatting Check
+        run: ruff format --check .
+      
       - name: Run tests
         run: pytest

--- a/README.md
+++ b/README.md
@@ -7,3 +7,58 @@ Create a static site generator from scratch. Translating Markdown text to HTML f
 ### Background
 
 A static site generator takes raw content files (like [Markdown](https://www.markdownguide.org/) and images) and turns them into a static website (a mix of [HTML](https://en.wikipedia.org/wiki/HTML) and [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) files).
+
+### Features
+
+- **Markdown Parsing**:
+  - Converts Markdown text into structured blocks (e.g., paragraphs, headings, lists, and code blocks).
+  - Supports inline formatting such as bold, italic, code, links, and images.
+
+- **HTML Node Generation**:
+  - Converts parsed Markdown into HTML nodes using `HTMLNode`, `LeafNode`, and `ParentNode` classes.
+  - Supports attributes like `href` for links and `src`/`alt` for images.
+
+- **Text Node Splitting**:
+  - Splits text into `TextNode` objects based on Markdown syntax.
+  - Handles nested formatting (e.g., bold and italic within the same text).
+
+- **Image and Link Extraction**:
+  - Extracts images and links from Markdown text using regex-based utilities.
+
+- **Testing**:
+  - Comprehensive unit tests for all major components:
+    - Markdown block splitting (`splitblocks.py`).
+    - Text node splitting and formatting (`splitnode.py`).
+    - HTML node generation (`htmlnode.py`).
+    - Markdown image and link extraction (`extract_markdown.py`).
+  - Tests ensure proper handling of edge cases, malformed Markdown, and nested structures.
+
+### Running the Project
+
+To execute the main script:
+
+```sh
+main.sh
+```
+
+### Running Tests
+To run all unit tests:
+
+```sh
+test.sh
+```
+
+#### Linting and Formatting
+- Lint check with Ruff: Run `ruff check src/` to check lint the code.
+> Reference: [ruff linter](https://docs.astral.sh/ruff/linter/)
+- Formatting with Ruff: Run `ruff format src/` or `ruff check src/ --fix` to run code formatting.
+> Reference: [ruff formatter](https://docs.astral.sh/ruff/formatter/)
+  - Note: pyproject.toml is a legacy file that defines the rules for linting and formatting inside src/ for black, isort, and some initial ruff configuration
+  - The ruff.toml is mostly the default settings except for the linelength is adjusted 120. 
+
+### Continuous Integration
+The project uses GitHub Actions to:
+
+- Run tests with pytest.
+- Perform linting with Ruff.
+- Check code formatting with Black.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,76 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+line-length = 120
+indent-width = 4
+
+# Assume Python 3.9
+target-version = "py39"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/src/htmlnode.py
+++ b/src/htmlnode.py
@@ -73,6 +73,4 @@ class ParentNode(HTMLNode):
 
     def __repr__(self):
         # Optional but helpful for debugging
-        return (
-            f"ParentNode(tag={self.tag}, children={self.children}, props={self.props})"
-        )
+        return f"ParentNode(tag={self.tag}, children={self.children}, props={self.props})"

--- a/src/main.py
+++ b/src/main.py
@@ -3,9 +3,7 @@ from textnode import TextNode, TextType
 
 
 def main():
-    my_node = TextNode(  # noqa: F841
-        "Sample Text", TextType.LINK, "https://www.google.com"
-    )
+    my_node = TextNode("Sample Text", TextType.LINK, "https://www.google.com")  # noqa: F841
 
 
 main()

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -25,3 +25,4 @@ warn_unused_ignores = true
 [tool.ruff]
 line-length = 120
 lint.extend-select = ["E501"]
+

--- a/src/splitnode.py
+++ b/src/splitnode.py
@@ -36,15 +36,11 @@ def _split_node(node, delimiter, text_type):
         if i % 2 == 0:
             nodes_list.append(TextNode(text_part, TextType.NORMAL))
         else:
-            nodes_list.append(
-                TextNode(text_part, SYMBOL_TO_TEXTTYPE.get(delimiter, text_type))
-            )
+            nodes_list.append(TextNode(text_part, SYMBOL_TO_TEXTTYPE.get(delimiter, text_type)))
     return nodes_list
 
 
-def split_nodes_delimiter(
-    old_nodes: list[TextNode], delimiter: str, text_type: TextType
-):
+def split_nodes_delimiter(old_nodes: list[TextNode], delimiter: str, text_type: TextType):
     """Use:
     node = TextNode("This is text with a `code block` word", TextType.TEXT)
     new_nodes = split_nodes_delimiter([node], "`", TextType.CODE)

--- a/src/test_extract_markdown.py
+++ b/src/test_extract_markdown.py
@@ -8,9 +8,7 @@ from splitnode import extract_markdown_images, extract_markdown_links
 
 class TestExtractMarkdown(unittest.TestCase):
     def test_extract_markdown_images(self):
-        matches = extract_markdown_images(
-            "This is text with an ![image](https://i.imgur.com/zjjcJKZ.png)"
-        )
+        matches = extract_markdown_images("This is text with an ![image](https://i.imgur.com/zjjcJKZ.png)")
         self.assertListEqual([("image", "https://i.imgur.com/zjjcJKZ.png")], matches)
 
     def test_extract_multiple_images(self):
@@ -38,9 +36,7 @@ class TestExtractMarkdown(unittest.TestCase):
         matches = extract_markdown_links(
             "This is text with an [link](https://test_your_might.com/@ricketyrickety_wrecked)"
         )
-        self.assertListEqual(
-            [("link", "https://test_your_might.com/@ricketyrickety_wrecked")], matches
-        )
+        self.assertListEqual([("link", "https://test_your_might.com/@ricketyrickety_wrecked")], matches)
 
     def test_extract_multiple_links(self):
         text = "[Google](https://google.com) and [GitHub](https://github.com)"

--- a/src/test_htmlnode.py
+++ b/src/test_htmlnode.py
@@ -34,9 +34,7 @@ class TestHTMLNode(unittest.TestCase):
             {"href": "https://www.google.com", "target": "_blank"},
         )
         props_to_html_return = node.props_to_html()
-        self.assertEqual(
-            props_to_html_return, ' href="https://www.google.com" target="_blank"'
-        )
+        self.assertEqual(props_to_html_return, ' href="https://www.google.com" target="_blank"')
 
     def test_to_html_error(self):
         """
@@ -92,9 +90,7 @@ class TestParentNode(unittest.TestCase):
         grandchild_node = LeafNode("b", "grandchild")
         child_node = ParentNode("span", [grandchild_node])
         parent_node = ParentNode("div", [child_node])
-        self.assertEqual(
-            parent_node.to_html(), "<div><span><b>grandchild</b></span></div>"
-        )
+        self.assertEqual(parent_node.to_html(), "<div><span><b>grandchild</b></span></div>")
 
     def test_parentnode_to_html_with_multiple_children(self):
         child_node1 = LeafNode("b", "child one bold text")

--- a/src/test_splitblocks.py
+++ b/src/test_splitblocks.py
@@ -80,9 +80,7 @@ This is another paragraph
         self.assertEqual(block_type, BlockType.QUOTE)
 
     def test_block_to_block_type_unordered_list(self):
-        block = (
-            "- This is an unordered list item\n- This is another unordered list item"
-        )
+        block = "- This is an unordered list item\n- This is another unordered list item"
         block_type = block_to_block_type(block)
         self.assertEqual(block_type, BlockType.UNORDERED_LIST)
 

--- a/src/test_splitnode.py
+++ b/src/test_splitnode.py
@@ -86,9 +86,7 @@ class TestSplitNode(unittest.TestCase):
                 TextNode("This is text with an ", TextType.NORMAL),
                 TextNode("image", TextType.IMAGE, "https://i.imgur.com/zjjcJKZ.png"),
                 TextNode(" and another ", TextType.NORMAL),
-                TextNode(
-                    "second image", TextType.IMAGE, "https://i.imgur.com/3elNhQu.png"
-                ),
+                TextNode("second image", TextType.IMAGE, "https://i.imgur.com/3elNhQu.png"),
             ],
             new_nodes,
         )
@@ -115,9 +113,7 @@ class TestSplitNode(unittest.TestCase):
         )
 
     def test_split_images_no_leading_text(self):
-        node = TextNode(
-            "![image](https://i.imgur.com/zjjcJKZ.png) and some text", TextType.NORMAL
-        )
+        node = TextNode("![image](https://i.imgur.com/zjjcJKZ.png) and some text", TextType.NORMAL)
         new_nodes = split_nodes_image([node])
         self.assertListEqual(
             [
@@ -136,9 +132,7 @@ class TestSplitNode(unittest.TestCase):
         self.assertListEqual(
             [
                 TextNode("Check this ", TextType.NORMAL),
-                TextNode(
-                    "an image: cat & dog", TextType.IMAGE, "https://img.com/catdog.png"
-                ),
+                TextNode("an image: cat & dog", TextType.IMAGE, "https://img.com/catdog.png"),
             ],
             new_nodes,
         )
@@ -225,9 +219,7 @@ class TestSplitNode(unittest.TestCase):
                 TextNode("This is text with an ", TextType.NORMAL),
                 TextNode("good_link", TextType.LINK, "https://the_mighty_googles.com/"),
                 TextNode(" and another ", TextType.NORMAL),
-                TextNode(
-                    "second link", TextType.LINK, "https://the_mighty_youtubes.com/"
-                ),
+                TextNode("second link", TextType.LINK, "https://the_mighty_youtubes.com/"),
             ],
             new_nodes,
         )
@@ -261,9 +253,7 @@ class TestSplitNode(unittest.TestCase):
         new_nodes = split_nodes_link([node])
         self.assertListEqual(
             [
-                TextNode(
-                    "golf_links", TextType.LINK, "https://denison_county_golfclub.net"
-                ),
+                TextNode("golf_links", TextType.LINK, "https://denison_county_golfclub.net"),
                 TextNode(" and some text", TextType.NORMAL),
             ],
             new_nodes,
@@ -288,9 +278,7 @@ class TestSplitNode(unittest.TestCase):
         )
 
     def test_split_link_malformed(self):
-        node = TextNode(
-            "Bad image [url_link](https://missing_Parens.com/image.png", TextType.NORMAL
-        )
+        node = TextNode("Bad image [url_link](https://missing_Parens.com/image.png", TextType.NORMAL)
         new_nodes = split_nodes_link([node])
         self.assertListEqual(
             [
@@ -314,9 +302,7 @@ class TestSplitNode(unittest.TestCase):
         )
 
     def test_split_links_with_newlines(self):
-        node = TextNode(
-            "Some text\n[newline](https://gottem)\nmore text", TextType.NORMAL
-        )
+        node = TextNode("Some text\n[newline](https://gottem)\nmore text", TextType.NORMAL)
         new_nodes = split_nodes_link([node])
         self.assertListEqual(
             [
@@ -328,9 +314,7 @@ class TestSplitNode(unittest.TestCase):
         )
 
     def test_split_links_same_image_repeated(self):
-        node = TextNode(
-            "[cat](https://cat_link) and again [cat](https://cat_link)", TextType.NORMAL
-        )
+        node = TextNode("[cat](https://cat_link) and again [cat](https://cat_link)", TextType.NORMAL)
         new_nodes = split_nodes_link([node])
         self.assertListEqual(
             [
@@ -350,9 +334,7 @@ class TestSplitNode(unittest.TestCase):
         self.assertListEqual(
             [
                 TextNode("This is ", TextType.NORMAL),
-                TextNode(
-                    "mindhive link", TextType.LINK, "https://inside_the_mindhive_url"
-                ),
+                TextNode("mindhive link", TextType.LINK, "https://inside_the_mindhive_url"),
                 TextNode(", and this too.", TextType.NORMAL),
             ],
             new_nodes,
@@ -371,9 +353,7 @@ class TestSplitNode(unittest.TestCase):
             TextNode(" word and a ", TextType.NORMAL, None),
             TextNode("code block", TextType.CODE, None),
             TextNode(" and an ", TextType.NORMAL, None),
-            TextNode(
-                "obi wan image", TextType.IMAGE, "https://i.imgur.com/fJRm4Vk.jpeg"
-            ),
+            TextNode("obi wan image", TextType.IMAGE, "https://i.imgur.com/fJRm4Vk.jpeg"),
             TextNode(" and a ", TextType.NORMAL, None),
             TextNode("link", TextType.LINK, "https://boot.dev"),
         ]

--- a/src/test_textnode.py
+++ b/src/test_textnode.py
@@ -46,9 +46,7 @@ class TestTextNode(unittest.TestCase):
         self.assertEqual(html_node.value, "Italics text node")
 
     def test_textnode_to_htmlnode_link(self):
-        node = TextNode(
-            "Click here phishing link!", TextType.LINK, "https://hackerwebs.com/"
-        )
+        node = TextNode("Click here phishing link!", TextType.LINK, "https://hackerwebs.com/")
         html_node = text_node_to_html_node(node)
         self.assertEqual(html_node.tag, "a")
         self.assertEqual(html_node.value, "Click here phishing link!")

--- a/src/textnode.py
+++ b/src/textnode.py
@@ -21,11 +21,7 @@ class TextNode:
         self.url = url
 
     def __eq__(self, other):
-        return (
-            self.text_type == other.text_type
-            and self.text == other.text
-            and self.url == other.url
-        )
+        return self.text_type == other.text_type and self.text == other.text and self.url == other.url
 
     def __repr__(self):
         return f"TextNode({self.text}, {self.text_type.value}, {self.url})"


### PR DESCRIPTION
Add ruff toml formatting file, but leave pyproject for backwards compatibility for other checks. Removed black from the gh actions check, and sticking with ruff for formatting and linting due to speed.
- **add ruff toml**
- **drop black from gh pr actions**
